### PR TITLE
add the posibility of specifying a url prefix

### DIFF
--- a/dpaste/settings/base.py
+++ b/dpaste/settings/base.py
@@ -51,6 +51,8 @@ MEDIA_ROOT = env("MEDIA_ROOT", ".media")
 
 STATIC_URL = "/static/"
 
+URL_PREFIX = env("URL_PREFIX", "")
+
 ROOT_URLCONF = "dpaste.urls"
 
 WSGI_APPLICATION = "dpaste.wsgi.application"

--- a/dpaste/urls/__init__.py
+++ b/dpaste/urls/__init__.py
@@ -1,9 +1,12 @@
 from django.urls import include, re_path
+from django.conf import settings
+
+url_prefix = getattr(settings, "URL_PREFIX", "")
 
 urlpatterns = [
-    re_path(r"^", include("dpaste.urls.dpaste_api")),
-    re_path(r"^", include("dpaste.urls.dpaste")),
-    re_path(r"^i18n/", include("django.conf.urls.i18n")),
+    re_path(r"^%s" % url_prefix, include("dpaste.urls.dpaste_api")),
+    re_path(r"^%s" % url_prefix, include("dpaste.urls.dpaste")),
+    re_path(r"^%si18n/" % url_prefix, include("django.conf.urls.i18n")),
 ]
 
 # Custom error handlers which load `dpaste/<code>.html` instead of `<code>.html`


### PR DESCRIPTION
this commit implements a prefix for urls, which allows easily deploying
dpaste into a "subdirectory". It adds a url_prefix to be read by default
from the environment which makes it especially suitable for using for
docker containers. For example, running

docker run -e PREFIX_URL=dpaste/ -p 8000:8000 barttc/dpaste

will make dpaste available on

http://localhost:8000/dpaste/

instead of the default http://localhost:8000

This is specially useful if you want to proxy dpaste from another host
and let it live in a sub-url. Without this commit all urls would be
incorrectly generated in this case.