### PR TITLE
Overflow code, not page

### DIFF
--- a/client/scss/components/_code.scss
+++ b/client/scss/components/_code.scss
@@ -17,6 +17,9 @@
     background-color: $codeDiffBgColor;
     white-space: pre;
     font-size: 12px;
+    
+    max-width: 100%;
+    overflow-x: auto;
   }
 }
 


### PR DESCRIPTION
If the code is very long in width, only the code will scroll, not the rest of the page. This will allow to not have weird things like the header going to the left when scrolling horizontally