### PR TITLE
Revert "add the posibility of specifying a url prefix"

### DIFF
--- a/dpaste/settings/base.py
+++ b/dpaste/settings/base.py
@@ -51,8 +51,6 @@ MEDIA_ROOT = env("MEDIA_ROOT", ".media")
 
 STATIC_URL = "/static/"
 
-URL_PREFIX = env("URL_PREFIX", "")
-
 ROOT_URLCONF = "dpaste.urls"
 
 WSGI_APPLICATION = "dpaste.wsgi.application"

--- a/dpaste/urls/__init__.py
+++ b/dpaste/urls/__init__.py
@@ -1,12 +1,9 @@
 from django.urls import include, re_path
-from django.conf import settings
-
-url_prefix = getattr(settings, "URL_PREFIX", "")
 
 urlpatterns = [
-    re_path(r"^%s" % url_prefix, include("dpaste.urls.dpaste_api")),
-    re_path(r"^%s" % url_prefix, include("dpaste.urls.dpaste")),
-    re_path(r"^%si18n/" % url_prefix, include("django.conf.urls.i18n")),
+    re_path(r"^", include("dpaste.urls.dpaste_api")),
+    re_path(r"^", include("dpaste.urls.dpaste")),
+    re_path(r"^i18n/", include("django.conf.urls.i18n")),
 ]
 
 # Custom error handlers which load `dpaste/<code>.html` instead of `<code>.html`


### PR DESCRIPTION
Reverts DarrenOfficial/dpaste#143

`format() argument must be a formatter instance, not a class`