### PR TITLE
fix: pygment crashes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,7 @@ python_requires = >=3.6
 install_requires =
     # Essential packages
     django>=3.2
-    pygments>=2.11
-    mysqlclient>=2.1.0
+    pygments<=2.11.2
     django-staticinline>=1.0
     django-csp>=3.6
     dj_database_url>=0.5.0


### PR DESCRIPTION
Dpaste crashes when something else than plain text is stored.

![](https://user-images.githubusercontent.com/428000/171509933-116ea4d2-105e-4d75-b731-0d2fad1c8fd7.png)

!! This is a temporary fix for the problem described above.

This fixes it by downgrading the pygment version.