### PR TITLE
CSP - Upstream Patch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,6 +59,6 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/i386
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           push: true
           tags: ${{ steps.prep.outputs.tags }}

--- a/dpaste/settings/base.py
+++ b/dpaste/settings/base.py
@@ -116,8 +116,9 @@ SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
 CSP_DEFAULT_SRC = ("'none'",)
-CSP_SCRIPT_SRC = ("'self'",)
-CSP_STYLE_SRC = ("'self'",)
+# If you edit the CSS/JS update your 256 HASH here.
+CSP_SCRIPT_SRC = ("'self'", "'unsafe-hashes'", "'sha256-634c702966ae36dcd81fe7a4c4756413be3b77af4f4a820651faecd1db1ab26a'",)
+CSP_STYLE_SRC = ("'self'", "'unsafe-hashes'", "'sha256-7ac9cd7ab2811dac84cdc031d0acf0f355a2ab619f633b857f6db5b4c2b45361'")
 
 LOGGING = {
     "version": 1,

--- a/dpaste/settings/base.py
+++ b/dpaste/settings/base.py
@@ -116,8 +116,8 @@ SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
 CSP_DEFAULT_SRC = ("'none'",)
-CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'")
-CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
+CSP_SCRIPT_SRC = ("'self'",)
+CSP_STYLE_SRC = ("'self'",)
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
"unsafe-inline" allows XSS reflection attack, mitigating it to use a HASH to ensure that the browser is executing the correct file.