### PR TITLE
Revert 239 csp

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,6 +59,6 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/i386
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           push: true
           tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,6 +59,6 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/i386
           push: true
           tags: ${{ steps.prep.outputs.tags }}

--- a/dpaste/settings/base.py
+++ b/dpaste/settings/base.py
@@ -116,9 +116,8 @@ SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
 CSP_DEFAULT_SRC = ("'none'",)
-# If you edit the CSS/JS update your 256 HASH here.
-CSP_SCRIPT_SRC = ("'self'", "'unsafe-hashes'", "'sha256-634c702966ae36dcd81fe7a4c4756413be3b77af4f4a820651faecd1db1ab26a'",)
-CSP_STYLE_SRC = ("'self'", "'unsafe-hashes'", "'sha256-7ac9cd7ab2811dac84cdc031d0acf0f355a2ab619f633b857f6db5b4c2b45361'")
+CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'")
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
Turns out the issue has been fixed from a long time ago, this commit AFAIK, https://github.com/DarrenOfficial/dpaste/commit/e3d4725e52503e68f95b55fc079ce5c5fc4bce69 therefore unsafe-inline was never an issue as tested in prod, and it appears to be blocking it correctly.