### PR TITLE
Fixes: (#256) - Plain Text Renderer ignores whitespace

### DIFF
--- a/client/scss/components/_text.scss
+++ b/client/scss/components/_text.scss
@@ -11,6 +11,7 @@ article {
   font-weight: $baseFontRegular;
   line-height: 24px;
   word-break: break-word;
+  white-space: pre;
 
   color: $textColor;
   max-width: 600px;


### PR DESCRIPTION
Text aligns to the left when there *should* be whitespaces.